### PR TITLE
add css to selectively hide the disclaimer banner

### DIFF
--- a/hide-static-banner.html
+++ b/hide-static-banner.html
@@ -1,0 +1,6 @@
+<style>
+    nysds-banner {display: none;}
+</style>
+    <!-- for drupal sites this code can be inserted into the full html source of the wysiwyg on the page that you would like to have the disclaimer hidden -->
+
+    <!-- for other websites, you'll need this code to exist inline, ONLY on the page or pages that you want the banner hidden. If you put this in a master stylesheet it won't display the banner anywhere, ever.  -->


### PR DESCRIPTION
Add a reference file for the inline css needed to hide the disclaimer banner on specific pages. Working example of this in prod on OGS at https://yi.ogs.ny.gov/new-york-state-language-access-law (or any of the translated versions of this page)